### PR TITLE
POST/articles のrequest specの実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -9,5 +9,18 @@ module Api::V1
       article = Article.find(params[:id])
       render json: article, each_serializer: Api::V1::ArticleSerializer
     end
+
+    def create
+      article = current_user.articles.create!(article_params)
+      render json: article, serializer: Api::V1::ArticleSerializer
+    end
+
+
+    private
+
+      def article_params
+        params.require(:article).permit(:title, :body)
+      end
+
   end
 end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,2 +1,6 @@
 class Api::V1::BaseApiController < ApplicationController
+
+  def current_user
+    @current_user ||= User.first
+  end
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -41,9 +41,23 @@ RSpec.describe "Api::V1::Articles", type: :request do
 
     context "指定したidの記事が存在しない時" do
       let(:article_id) {100000}
-      fit "記事が見tuからない" do
+      it "記事が見つからない" do
         expect{subject}.to raise_error(ActiveRecord::RecordNotFound)
       end
+    end
+  end
+
+  describe "POST /articles" do
+    subject {post(api_v1_articles_path, params: params)}
+
+    let(:params) {{article: attributes_for(:article)}}
+    let(:current_user) {create(:user)}
+    fit "記事のレコードが作成できる" do
+      expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
+      res = JSON.parse(response.body)
+      expect(res["title"]).to eq params[:article][:title]
+      expect(res["body"]).to eq params[:article][:body]
+      expect(response).to have_http_status(200)
     end
   end
 end


### PR DESCRIPTION
# POST/articles のrequest specの実装
 - bace_api_controllerにcurrent_userを定義